### PR TITLE
Selinux docker check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,14 @@
----
+sudo: required
 language: python
-python: "2.7"
 
-# Use the new container infrastructure
-sudo: false
-
-# Install ansible
-addons:
-  apt:
-    packages:
-    - python-pip
+services:
+  - docker
 
 install:
-  # Install ansible
-  - pip install ansible
-
-  # Check ansible version
-  - ansible --version
-
-  # Create ansible.cfg with correct roles_path
-  - printf '[defaults]\nroles_path=../' >ansible.cfg
+  - pip install ansible docker-py molecule
 
 script:
-  # Basic role syntax check
-  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+  - molecule test
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/molecule.yml
+++ b/molecule.yml
@@ -1,0 +1,28 @@
+---
+dependency: []
+
+# Default driver
+driver:
+  name: docker
+
+vagrant:
+  platforms:
+    - name: centos7
+      box: centos/7
+  providers:
+    - name: virtualbox
+      type: virtualbox
+      options:
+        memory: 512
+        cpus: 1
+  instances:
+    - name: selinux-utils
+
+docker:
+  containers:
+  - name: selinux-utils
+    image: centos
+    image_version: 7
+
+verifier:
+  name: testinfra

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,0 +1,4 @@
+---
+- hosts: all
+  roles:
+    - role: ansible-role-selinux-utils

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,21 +4,26 @@
 # NOTE: The Ansible variable `ansible_selinux.status == "enabled"` should
 # autodetect SELinux, but may give a misleading result if a dependency is
 # missing: https://github.com/ansible/ansible/issues/16612
-# so use getsestatus instead
+# so use getenforce instead
 
 # Always run including in check mode
+- name: selinux | check exists
+  stat:
+    path: /sbin/getenforce
+  register: selinux_getenforce_st
+  always_run: True
+
 - name: selinux | check enabled
   become: yes
   command: getenforce
   register: selinux_getenforce
   always_run: True
-  failed_when: "selinux_getenforce.rc != 0 and selinux_getenforce.rc != 127"
   changed_when: False
-  # 127=command not found, implies selinux disabled
+  when: selinux_getenforce_st.stat.exists
 
 - name: system packages | set selinux variable
   set_fact:
-    selinux_enabled: "{{ selinux_getenforce.rc == 0 and selinux_getenforce.stdout != 'Disabled' }}"
+    selinux_enabled: "{{ selinux_getenforce_st.stat.exists and selinux_getenforce.stdout != 'Disabled' }}"
 
 - name: system packages | install selinux utilities
   become: yes

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,1 +1,0 @@
-localhost

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,5 +1,0 @@
----
-- hosts: localhost
-  remote_user: root
-  roles:
-  - role: ansible-role-selinux-utils

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -1,0 +1,18 @@
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    '.molecule/ansible_inventory').get_hosts('all')
+
+
+# The behaviour of this test depends on whether it's running with a docker
+# container or full VM
+def test_selinux_utils(Command, Package):
+    if Command.exists('getenforce'):
+        getenforce = Command.check_output('getenforce')
+    else:
+        getenforce = None
+
+    if getenforce == 'Disabled':
+        assert not Package('policycoreutils-python')
+    else:
+        assert Package('policycoreutils-python')


### PR DESCRIPTION
`molecule`/`ansible` use `docker exec` to run some commands, which behaves differently from a shell, e.g. a missing command returns a different error code. This PR changes the test to explicitly check for the presence of `/sbin/getenforce` https://github.com/openmicroscopy/ansible-role-selinux-utils/pull/1/commits/3dd4499785b7cecf2e14ee90fb435f3f61202642. This change is required for testing another role  (in development) that requires `openmicroscopy.selinux` (https://github.com/manics/ansible-role-rsync-server)