### PR TITLE
Use /usr/sbin/getenforce

### DIFF
--- a/molecule.yml
+++ b/molecule.yml
@@ -16,11 +16,11 @@ vagrant:
         memory: 512
         cpus: 1
   instances:
-    - name: selinux-utils
+    - name: selinux-utils-vagrant
 
 docker:
   containers:
-  - name: selinux-utils
+  - name: selinux-utils-docker
     image: centos
     image_version: 7
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,13 +9,13 @@
 # Always run including in check mode
 - name: selinux | check exists
   stat:
-    path: /sbin/getenforce
+    path: /usr/sbin/getenforce
   register: selinux_getenforce_st
   check_mode: no
 
 - name: selinux | check enabled
   become: yes
-  command: getenforce
+  command: /usr/sbin/getenforce
   register: selinux_getenforce
   check_mode: no
   changed_when: False

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -6,13 +6,15 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 # The behaviour of this test depends on whether it's running with a docker
 # container or full VM
-def test_selinux_utils(Command, Package):
-    if Command.exists('getenforce'):
-        getenforce = Command.check_output('getenforce')
-    else:
-        getenforce = None
+def test_selinux_utils(Command, Package, TestinfraBackend):
+    # We could do this by having separate test_files, but by keeping it
+    # in one we can guarantee we always match one of the test conditions
+    host = TestinfraBackend.get_hostname()
 
-    if getenforce == 'Disabled':
-        assert not Package('policycoreutils-python')
+    if host == 'selinux-utils-docker':
+        assert not Command.exists('/usr/sbin/getenforce')
+        assert not Package('policycoreutils-python').is_installed
     else:
-        assert Package('policycoreutils-python')
+        getenforce = Command.check_output('/usr/sbin/getenforce')
+        assert getenforce == 'Enforcing'
+        assert Package('policycoreutils-python').is_installed


### PR DESCRIPTION
Fixes an issue reported in https://github.com/openmicroscopy/infrastructure/pull/285

The default `PATH` varies, so use the full `/usr/sbin/getenforce` command path.

Tag: `1.0.3`