### PR TITLE
Fix ansible complaining of deprecation warning

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   description: Installs utilities and sets variable for interacting with SELinux
   company: Open Microscopy Environment
   license: BSD
-  min_ansible_version: 2.2
+  min_ansible_version: 2.3
   platforms:
   - name: EL
     versions:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,6 +28,9 @@
 - name: system packages | install selinux utilities
   become: yes
   package:
-    name: ["libselinux-python", "libsemanage-python", "policycoreutils-python"]
+    name:
+      - libselinux-python
+      - libsemanage-python
+      - policycoreutils-python
     state: present
   when: selinux_enabled

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,11 +27,7 @@
 
 - name: system packages | install selinux utilities
   become: yes
-  yum:
-    name: "{{ item }}"
+  package:
+    name: ["libselinux-python", "libsemanage-python", "policycoreutils-python"]
     state: present
-  with_items:
-    - libselinux-python
-    - libsemanage-python
-    - policycoreutils-python
   when: selinux_enabled


### PR DESCRIPTION
Hello,

This PR fixes the following warning:
```
TASK [openmicroscopy.selinux-utils : system packages | install selinux utilities] **************************************************************************************************************************************************************************************************************************************************************************************************
[DEPRECATION WARNING]: Invoking "yum" only once while using a loop via squash_actions is deprecated. Instead of using a loop to supply multiple items and specifying `name: "{{ item }}"`, please use `name: ['libselinux-python', 'libsemanage-python', 'policycoreutils-python']` and remove the loop. This feature will be removed in version 2.11. Deprecation warnings can be
disabled by setting deprecation_warnings=False in ansible.cfg.```
